### PR TITLE
feat: add prelude module for simplified imports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,46 @@ pub use ui::*;
 
 use crate::position::Position;
 
+/// Prelude module that re-exports commonly used types and traits
+pub mod prelude {
+    pub use crate::{
+        // Core types
+        position::{Position, Vector},
+        BoundingBox, Transform2D, Mirroring,
+        
+        // Layer and primitives
+        GerberLayer, GerberPrimitive,
+        
+        // Enums
+        Exposure, Winding,
+        
+        // Functions
+        calculate_winding,
+    };
+    
+    #[cfg(feature = "egui")]
+    pub use crate::{
+        // Renderer
+        GerberRenderer, ViewState,
+        
+        // UI
+        UiState,
+        
+        // Drawing functions
+        draw_crosshair, draw_arrow, draw_outline, draw_marker,
+        
+        // Color utilities
+        generate_pastel_color, hsv_to_rgb,
+    };
+    
+    // Re-export parser and types if features are enabled
+    #[cfg(feature = "parser")]
+    pub use crate::gerber_parser;
+    
+    #[cfg(feature = "types")]
+    pub use crate::gerber_types;
+}
+
 pub enum Winding {
     /// Aka 'Positive' in Geometry
     Clockwise,


### PR DESCRIPTION
Adds a prelude module following Rust conventions to provide easy access to commonly used types and functions.

Users can now use: use gerber_viewer::prelude::*;

(This is a cleaned up version of the previous pull request that had prelude + demo changes, this commit is prelude only changes)