### PR TITLE
Migrate to nalgebra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ gerber_parser = { git = "https://github.com/makerpnp/gerber-parser.git", rev = "
 # Math
 rand = "0.9.1"
 lyon = "1.0"
-nalgebra = { version = "0.33.2" , features = ["std"] }
+nalgebra = { version = "0.33.2" , default-features = false }
 
 # Errors
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ gerber_parser = { git = "https://github.com/makerpnp/gerber-parser.git", rev = "
 # Math
 rand = "0.9.1"
 lyon = "1.0"
+nalgebra = { version = "0.33.2" , features = ["std"] }
 
 # Errors
 thiserror = "2.0.12"

--- a/demo/Cargo.lock
+++ b/demo/Cargo.lock
@@ -237,6 +237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arboard"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1349,7 @@ dependencies = [
  "gerber_types",
  "log",
  "lyon",
+ "nalgebra",
  "profiling",
  "rand 0.9.1",
  "thiserror 2.0.12",
@@ -2024,6 +2034,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2115,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,6 +2206,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2846,6 +2902,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2937,6 +2999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,6 +3096,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -3775,6 +3859,16 @@ dependencies = [
  "js-sys",
  "log",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/demo/Cargo.lock
+++ b/demo/Cargo.lock
@@ -1363,6 +1363,7 @@ dependencies = [
  "egui",
  "env_logger",
  "gerber_viewer",
+ "nalgebra",
  "profiling",
  "puffin_http",
  "tracing",

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -12,6 +12,7 @@ env_logger = "0.11.8"
 profiling = "1.0.16"
 puffin_http = { version = "0.16.1", optional = true}
 tracing = "0.1.41"
+nalgebra = "0.33.2"
 
 [features]
 profile-with-puffin = [

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -3,8 +3,9 @@ use std::io::BufReader;
 use eframe::emath::{Rect, Vec2};
 use eframe::epaint::Color32;
 use egui::ViewportBuilder;
+use nalgebra::Vector2;
 use gerber_viewer::gerber_parser::parse;
-use gerber_viewer::{draw_arrow, draw_outline, draw_crosshair, BoundingBox, GerberLayer, GerberRenderer, Transform2D, Vector, ViewState, draw_marker, UiState, ToPosition};
+use gerber_viewer::{draw_arrow, draw_outline, draw_crosshair, BoundingBox, GerberLayer, GerberRenderer, Transform2D, ViewState, draw_marker, UiState, ToPosition};
 
 const ENABLE_UNIQUE_SHAPE_COLORS: bool = true;
 const ENABLE_POLYGON_NUMBERING: bool = false;
@@ -14,12 +15,12 @@ const INITIAL_ROTATION: f32 = 45.0_f32.to_radians();
 const MIRRORING: [bool; 2] = [false, false];
 
 // for mirroring and rotation
-const CENTER_OFFSET: Vector = Vector::new(15.0, 20.0);
+const CENTER_OFFSET: Vector2<f64> = Vector2::new(15.0, 20.0);
 //const CENTER_OFFSET: Vector = Vector::new(14.75, 6.0);
 
 // in EDA tools like DipTrace, a gerber offset can be specified when exporting gerbers, e.g. 10,5.
 // use negative offsets here to relocate the gerber back to 0,0, e.g. -10, -5
-const DESIGN_OFFSET: Vector = Vector::new(-5.0, -10.0);
+const DESIGN_OFFSET: Vector2<f64> = Vector2::new(-5.0, -10.0);
 //const DESIGN_OFFSET: Vector = Vector::new(-10.0, -10.0);
 
 // radius of the markers, in gerber coordinates

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -4,7 +4,7 @@ use eframe::emath::{Rect, Vec2};
 use eframe::epaint::Color32;
 use egui::ViewportBuilder;
 use gerber_viewer::gerber_parser::parse;
-use gerber_viewer::{draw_arrow, draw_outline, draw_crosshair, BoundingBox, GerberLayer, GerberRenderer, Transform2D, Vector, ViewState, draw_marker, UiState};
+use gerber_viewer::{draw_arrow, draw_outline, draw_crosshair, BoundingBox, GerberLayer, GerberRenderer, Transform2D, Vector, ViewState, draw_marker, UiState, ToPosition};
 
 const ENABLE_UNIQUE_SHAPE_COLORS: bool = true;
 const ENABLE_POLYGON_NUMBERING: bool = false;

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,7 +1,6 @@
 use egui::{Pos2, Vec2, Vec2b};
 use log::debug;
-use crate::spacial::Vector;
-use crate::Position;
+use nalgebra::{Point2, Vector2};
 
 #[derive(Debug, Copy, Clone)]
 pub struct Mirroring {
@@ -53,14 +52,14 @@ pub struct Transform2D {
     pub rotation_radians: f32,
     pub mirroring: Mirroring,
     // origin for rotation and mirroring, in gerber coordinates
-    pub origin: Vector,
+    pub origin: Vector2<f64>,
     // offset, in gerber coordinates
-    pub offset: Vector,
+    pub offset: Vector2<f64>,
 }
 
 impl Transform2D {
-    /// Apply the transform to a logical `Position` (Gerber-space)
-    pub fn apply_to_position(&self, pos: Position) -> Position {
+    /// Apply the transform to a logical `Point2` (Gerber-space)
+    pub fn apply_to_position(&self, pos: Point2<f64>) -> Point2<f64> {
         let mut x = pos.x - self.origin.x;
         let mut y = pos.y - self.origin.y;
 
@@ -75,13 +74,13 @@ impl Transform2D {
         let rotated_x = x * cos_theta - y * sin_theta;
         let rotated_y = x * sin_theta + y * cos_theta;
 
-        Position::new(
+        Point2::new(
             rotated_x + self.origin.x + self.offset.x,
             rotated_y + self.origin.y + self.offset.y,
         )
     }
 
-    /// Apply transform to a Vec2 instead of Position (used for bbox drawing)
+    /// Apply transform to a Vec2 instead of Point2 (used for bbox drawing)
     pub fn apply_to_pos2(&self, pos: Pos2) -> Vec2 {
         let mut x = pos.x as f64 - self.origin.x;
         let mut y = pos.y as f64 - self.origin.y;
@@ -106,13 +105,13 @@ impl Transform2D {
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct BoundingBox {
-    pub min: Position,
-    pub max: Position,
+    pub min: Point2<f64>,
+    pub max: Point2<f64>,
 }
 
 impl BoundingBox {
     /// Use to generate an outline of the bbox
-    pub fn transform_vertices(&self, transform: Transform2D) -> Vec<Position> {
+    pub fn transform_vertices(&self, transform: Transform2D) -> Vec<Point2<f64>> {
         self.vertices()
             .into_iter()
             .map(|v| transform.apply_to_position(v))
@@ -130,8 +129,8 @@ impl BoundingBox {
 impl Default for BoundingBox {
     fn default() -> Self {
         Self {
-            min: Position::new(f64::MAX, f64::MAX),
-            max: Position::new(f64::MIN, f64::MIN),
+            min: Point2::new(f64::MAX, f64::MAX),
+            max: Point2::new(f64::MIN, f64::MIN),
         }
     }
 }
@@ -170,11 +169,10 @@ impl BoundingBox {
     }
 
     /// Returns a new bounding box with X and/or Y mirroring applied.
-    pub fn apply_mirroring(&self, mirror_x: bool, mirror_y: bool, offset: Vector) -> Self {
+    pub fn apply_mirroring(&self, mirror_x: bool, mirror_y: bool, offset: Vector2<f64>) -> Self {
         let mut vertices = self.vertices();
 
-        for position  in &mut vertices
-        {
+        for position in &mut vertices {
             if mirror_x {
                 position.x = offset.x - (position.x - offset.x);
             }
@@ -187,7 +185,7 @@ impl BoundingBox {
     }
 
     /// Returns a new bounding box rotated around origin (0, 0) by given angle in radians.
-    pub fn apply_rotation(&self, radians: f64, offset: Vector) -> Self {
+    pub fn apply_rotation(&self, radians: f64, offset: Vector2<f64>) -> Self {
         let (sin_theta, cos_theta) = radians.sin_cos();
         let mut corners = self.vertices();
 
@@ -205,9 +203,9 @@ impl BoundingBox {
         Self::from_points(&corners)
     }
 
-    /// Returns the geometric center of the bounding box as a Position
-    pub fn center(&self) -> Position {
-        Position::new(self.min.x + self.max.x, self.min.y + self.max.y) / 2.0 
+    /// Returns the geometric center of the bounding box as a Point2
+    pub fn center(&self) -> Point2<f64> {
+        Point2::new(self.min.x + self.max.x, self.min.y + self.max.y) / 2.0
     }
 
     /// Returns 4 corner points of the bounding box such that the result is useable as a closed path.
@@ -216,22 +214,21 @@ impl BoundingBox {
     ///                  │            │
     /// (min_x, max_y) 4 └────────────┘ 3 (max_x, max_y)
     /// ```
-    pub fn vertices(&self) -> Vec<Position> {
+    pub fn vertices(&self) -> Vec<Point2<f64>> {
         vec![
-            Position::new(self.min.x, self.min.y),
-            Position::new(self.max.x, self.min.y),
-            Position::new(self.max.x, self.max.y),
-            Position::new(self.min.x, self.max.y),
+            Point2::new(self.min.x, self.min.y),
+            Point2::new(self.max.x, self.min.y),
+            Point2::new(self.max.x, self.max.y),
+            Point2::new(self.min.x, self.max.y),
         ]
     }
 
     /// Constructs a bounding box from a list of points
-    pub fn from_points(points: &[Position]) -> Self {
-        let mut min = Position::new(f64::MAX, f64::MAX);
-        let mut max = Position::new(f64::MIN, f64::MIN);
+    pub fn from_points(points: &[Point2<f64>]) -> Self {
+        let mut min = Point2::new(f64::MAX, f64::MAX);
+        let mut max = Point2::new(f64::MIN, f64::MIN);
 
-        for position in points
-        {
+        for position in points {
             min.x = min.x.min(position.x);
             min.y = min.y.min(position.y);
             max.x = max.x.max(position.x);
@@ -247,16 +244,15 @@ impl BoundingBox {
 
 #[cfg(test)]
 mod bbox_tests {
+    use nalgebra::{Point2, Vector2};
     use rstest::rstest;
 
     use super::BoundingBox;
-    use crate::spacial::Vector;
-    use crate::Position;
 
     #[rstest]
     #[case(BoundingBox::default(), true)]
-    #[case(BoundingBox { min: Position::new(0.0, 0.0), max: Position::new(0.0, 0.0) }, false)]
-    #[case(BoundingBox { min: Position::new(-10.0, -10.0), max: Position::new(10.0, 10.0) }, false)]
+    #[case(BoundingBox { min: Point2::new(0.0, 0.0), max: Point2::new(0.0, 0.0) }, false)]
+    #[case(BoundingBox { min: Point2::new(-10.0, -10.0), max: Point2::new(10.0, 10.0) }, false)]
     pub fn test_is_empty(#[case] input: BoundingBox, #[case] expected: bool) {
         assert_eq!(input.is_empty(), expected);
     }
@@ -264,11 +260,11 @@ mod bbox_tests {
     #[test]
     pub fn test_apply_rotation_90_degrees_zero_offset() {
         let bbox = BoundingBox {
-            min: Position::new(1.0, 2.0),
-            max: Position::new(3.0, 4.0),
+            min: Point2::new(1.0, 2.0),
+            max: Point2::new(3.0, 4.0),
         };
 
-        let rotated = bbox.apply_rotation(std::f64::consts::FRAC_PI_2, Vector::new(0.0, 0.0)); // 90 degrees
+        let rotated = bbox.apply_rotation(std::f64::consts::FRAC_PI_2, Vector2::new(0.0, 0.0)); // 90 degrees
 
         // Expected:
         // Points rotate CCW around origin:
@@ -297,8 +293,8 @@ mod bbox_tests {
     fn test_geometric_center(#[case] origin: (f64, f64), #[case] size: (f64, f64), #[case] expected: (f64, f64)) {
         // Create bounding box from origin and size
         let bbox = BoundingBox {
-            min: Position::new(origin.0, origin.1),
-            max: Position::new(origin.0 + size.0, origin.1 + size.1),
+            min: Point2::new(origin.0, origin.1),
+            max: Point2::new(origin.0 + size.0, origin.1 + size.1),
         };
 
         let center = bbox.center();
@@ -320,7 +316,7 @@ mod bbox_tests {
     }
 }
 
-pub fn is_convex(vertices: &[Position]) -> bool {
+pub fn is_convex(vertices: &[Point2<f64>]) -> bool {
     if vertices.len() < 3 {
         return true;
     }
@@ -355,7 +351,7 @@ pub struct PolygonMesh {
     pub indices: Vec<u32>,
 }
 
-pub fn tessellate_polygon(vertices: &[Position]) -> PolygonMesh {
+pub fn tessellate_polygon(vertices: &[Point2<f64>]) -> PolygonMesh {
     use lyon::path::Path;
     use lyon::tessellation::{BuffersBuilder, FillOptions, FillRule, FillTessellator, VertexBuffers};
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,6 +1,5 @@
 use egui::{Pos2, Vec2, Vec2b};
 use log::debug;
-
 use crate::spacial::Vector;
 use crate::Position;
 
@@ -131,8 +130,8 @@ impl BoundingBox {
 impl Default for BoundingBox {
     fn default() -> Self {
         Self {
-            min: Position::MAX,
-            max: Position::MIN,
+            min: Position::new(f64::MAX, f64::MAX),
+            max: Position::new(f64::MIN, f64::MIN),
         }
     }
 }
@@ -174,16 +173,13 @@ impl BoundingBox {
     pub fn apply_mirroring(&self, mirror_x: bool, mirror_y: bool, offset: Vector) -> Self {
         let mut vertices = self.vertices();
 
-        for Position {
-            x,
-            y,
-        } in &mut vertices
+        for position  in &mut vertices
         {
             if mirror_x {
-                *x = offset.x - (*x - offset.x);
+                position.x = offset.x - (position.x - offset.x);
             }
             if mirror_y {
-                *y = offset.y - (*y - offset.y);
+                position.y = offset.y - (position.y - offset.y);
             }
         }
 
@@ -211,7 +207,7 @@ impl BoundingBox {
 
     /// Returns the geometric center of the bounding box as a Position
     pub fn center(&self) -> Position {
-        (self.min + self.max) / 2.0
+        Position::new(self.min.x + self.max.x, self.min.y + self.max.y) / 2.0 
     }
 
     /// Returns 4 corner points of the bounding box such that the result is useable as a closed path.
@@ -231,18 +227,15 @@ impl BoundingBox {
 
     /// Constructs a bounding box from a list of points
     pub fn from_points(points: &[Position]) -> Self {
-        let mut min = Position::MAX;
-        let mut max = Position::MIN;
+        let mut min = Position::new(f64::MAX, f64::MAX);
+        let mut max = Position::new(f64::MIN, f64::MIN);
 
-        for &Position {
-            x,
-            y,
-        } in points
+        for position in points
         {
-            min.x = min.x.min(x);
-            min.y = min.y.min(y);
-            max.x = max.x.max(x);
-            max.y = max.y.max(y);
+            min.x = min.x.min(position.x);
+            min.y = min.y.min(position.y);
+            max.x = max.x.max(position.x);
+            max.y = max.y.max(position.y);
         }
 
         Self {
@@ -275,7 +268,7 @@ mod bbox_tests {
             max: Position::new(3.0, 4.0),
         };
 
-        let rotated = bbox.apply_rotation(std::f64::consts::FRAC_PI_2, Vector::ZERO); // 90 degrees
+        let rotated = bbox.apply_rotation(std::f64::consts::FRAC_PI_2, Vector::new(0.0, 0.0)); // 90 degrees
 
         // Expected:
         // Points rotate CCW around origin:
@@ -304,14 +297,8 @@ mod bbox_tests {
     fn test_geometric_center(#[case] origin: (f64, f64), #[case] size: (f64, f64), #[case] expected: (f64, f64)) {
         // Create bounding box from origin and size
         let bbox = BoundingBox {
-            min: Position {
-                x: origin.0,
-                y: origin.1,
-            },
-            max: Position {
-                x: origin.0 + size.0,
-                y: origin.1 + size.1,
-            },
+            min: Position::new(origin.0, origin.1),
+            max: Position::new(origin.0 + size.0, origin.1 + size.1),
         };
 
         let center = bbox.center();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -5,9 +5,9 @@ use egui::epaint::{
     Color32, ColorMode, FontId, Mesh, PathShape, PathStroke, Pos2, Rect, Shape, Stroke, StrokeKind, Vec2, Vertex,
 };
 use egui::Painter;
+use nalgebra::Vector2;
 
 use crate::layer::{GerberPrimitive, ViewState};
-use crate::spacial::Vector;
 use crate::{color, GerberLayer, Mirroring};
 use crate::{
     ArcGerberPrimitive, CircleGerberPrimitive, LineGerberPrimitive, PolygonGerberPrimitive, RectangleGerberPrimitive,
@@ -31,12 +31,12 @@ impl GerberRenderer {
         rotation: f32,
         mirroring: Mirroring,
         // in gerber coordinates
-        design_origin: Vector,
+        design_origin: Vector2<f64>,
         // in gerber coordinates
-        design_offset: Vector,
+        design_offset: Vector2<f64>,
     ) {
-        let relative_origin = Vector::new(design_origin.x, -design_origin.y);
-        let offset = Vector::new(design_offset.x, -design_offset.y);
+        let relative_origin = Vector2::new(design_origin.x, -design_origin.y);
+        let offset = Vector2::new(design_offset.x, -design_offset.y);
 
         let origin = relative_origin - offset;
 

--- a/src/spacial.rs
+++ b/src/spacial.rs
@@ -1,322 +1,98 @@
-use std::ops::Add;
-
 #[cfg(feature = "egui")]
 use egui::{Pos2, Vec2};
 
-#[allow(dead_code)]
-impl Position {
-    #[cfg(feature = "egui")]
-    pub const fn to_pos2(self) -> Pos2 {
+#[cfg(feature = "egui")]
+pub trait ToPos2 {
+    fn to_pos2(self) -> Pos2;
+}
+
+#[cfg(feature = "egui")]
+impl ToPos2 for Position {
+    fn to_pos2(self) -> Pos2 {
         Pos2::new(self.x as f32, self.y as f32)
     }
+}
 
-    pub const fn to_vector(self) -> Vector {
-        Vector {
-            x: self.x,
-            y: self.y,
-        }
+pub trait ToVector {
+    fn to_vector(self) -> Vector;
+}
+
+impl ToVector for Position {
+    fn to_vector(self) -> Vector {
+        Vector::new(self.x, self.y)
     }
 }
 
 #[cfg(feature = "egui")]
-impl From<Vec2> for Position {
+pub trait FromVec2 {
+    fn from(value: Vec2) -> Self;
+}
+
+#[cfg(feature = "egui")]
+impl FromVec2 for Position {
     fn from(value: Vec2) -> Self {
-        Self {
-            x: value.x as f64,
-            y: value.y as f64,
-        }
+        Self::new(value.x as f64, value.y as f64)
     }
 }
 
-impl From<(f64, f64)> for Position {
+pub trait FromTuple2 {
+    fn from(value: (f64, f64)) -> Self;
+}
+
+impl FromTuple2 for Position {
     fn from(value: (f64, f64)) -> Self {
-        Self {
-            x: value.0,
-            y: value.1,
-        }
+        Self::new(value.0, value.1)
     }
 }
 
 #[cfg(feature = "egui")]
-impl Add<Vec2> for Position {
-    type Output = Position;
+pub trait AddVec2 {
+    fn add(self, rhs: Vec2) -> Self;
+}
 
-    fn add(self, rhs: Vec2) -> Self::Output {
-        Self::Output {
-            x: self.x + rhs.x as f64,
-            y: self.y + rhs.y as f64,
-        }
+#[cfg(feature = "egui")]
+impl AddVec2 for Position {
+
+    fn add(self, rhs: Vec2) -> Self {
+        Self::new(self.x + rhs.x as f64, self.y + rhs.y as f64)
     }
 }
 
-impl Vector {
-    pub const fn to_position(self) -> Position {
-        Position {
-            x: self.x,
-            y: self.y,
-        }
+pub trait ToPosition {
+    fn to_position(self) -> Position;
+}
+
+impl ToPosition for Vector {
+    fn to_position(self) -> Position {
+        Position::new(self.x, self.y)
     }
 }
 
-macro_rules! impl_constructor {
-    ($name:ident, $t:ty) => {
-        #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
-        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        pub struct $name {
-            pub x: $t,
-            pub y: $t,
-        }
-
-        impl $name {
-            pub const fn new(x: $t, y: $t) -> Self {
-                Self {
-                    x,
-                    y,
-                }
-            }
-        }
-    };
-}
-
-macro_rules! impl_consts {
-    ($name:ident, $t:ty) => {
-        impl $name {
-            pub const ZERO: $name = $name::new(0.0, 0.0);
-            pub const MAX: $name = $name::new(<$t>::MAX, <$t>::MAX);
-            pub const MIN: $name = $name::new(<$t>::MIN, <$t>::MIN);
-            pub const INFINITY: $name = $name::new(<$t>::INFINITY, <$t>::INFINITY);
-        }
-
-        impl Default for $name {
-            fn default() -> Self {
-                Self::ZERO
-            }
-        }
-    };
-}
-macro_rules! impl_ops_self {
-    ($name:ident) => {
-        impl core::ops::Add for $name {
-            type Output = Self;
-
-            fn add(self, rhs: Self) -> Self::Output {
-                Self {
-                    x: self.x + rhs.x,
-                    y: self.y + rhs.y,
-                }
-            }
-        }
-
-        impl core::ops::Sub for $name {
-            type Output = Self;
-
-            fn sub(self, rhs: Self) -> Self::Output {
-                Self {
-                    x: self.x - rhs.x,
-                    y: self.y - rhs.y,
-                }
-            }
-        }
-
-        impl core::ops::Mul for $name {
-            type Output = Self;
-
-            fn mul(self, rhs: Self) -> Self::Output {
-                Self {
-                    x: self.x * rhs.x,
-                    y: self.y * rhs.y,
-                }
-            }
-        }
-
-        impl core::ops::Div for $name {
-            type Output = Self;
-
-            fn div(self, rhs: Self) -> Self::Output {
-                Self {
-                    x: self.x / rhs.x,
-                    y: self.y / rhs.y,
-                }
-            }
-        }
-
-        impl core::ops::Div<f64> for $name {
-            type Output = $name;
-
-            fn div(self, rhs: f64) -> Self::Output {
-                Self {
-                    x: self.x / rhs,
-                    y: self.y / rhs,
-                }
-            }
-        }
-
-        impl core::ops::Mul<f64> for $name {
-            type Output = $name;
-
-            fn mul(self, rhs: f64) -> Self::Output {
-                Self {
-                    x: self.x * rhs,
-                    y: self.y * rhs,
-                }
-            }
-        }
-
-        impl core::ops::Add<f64> for $name {
-            type Output = $name;
-
-            fn add(self, rhs: f64) -> Self::Output {
-                Self {
-                    x: self.x + rhs,
-                    y: self.y + rhs,
-                }
-            }
-        }
-
-        impl core::ops::Sub<f64> for $name {
-            type Output = $name;
-
-            fn sub(self, rhs: f64) -> Self::Output {
-                Self {
-                    x: self.x - rhs,
-                    y: self.y - rhs,
-                }
-            }
-        }
-
-        impl core::ops::AddAssign for $name {
-            fn add_assign(&mut self, rhs: Self) {
-                self.x += rhs.x;
-                self.y += rhs.y;
-            }
-        }
-
-        impl core::ops::SubAssign for $name {
-            fn sub_assign(&mut self, rhs: Self) {
-                self.x -= rhs.x;
-                self.y -= rhs.y;
-            }
-        }
-
-        impl core::ops::MulAssign for $name {
-            fn mul_assign(&mut self, rhs: Self) {
-                self.x *= rhs.x;
-                self.y *= rhs.y;
-            }
-        }
-
-        impl core::ops::DivAssign for $name {
-            fn div_assign(&mut self, rhs: Self) {
-                self.x /= rhs.x;
-                self.y /= rhs.y;
-            }
-        }
-    };
+pub trait Invert {
+    fn invert_x(self) -> Self;
+    fn invert_y(self) -> Self;
 }
 
 macro_rules! impl_invert {
     ($name:ident) => {
-        impl $name {
-            pub const fn invert_x(self) -> Self {
-                Self {
-                    x: -self.x,
-                    y: self.y,
-                }
+        impl Invert for $name {
+            fn invert_x(self) -> Self {
+                Self::new(-self.x, self.y)
             }
 
-            pub const fn invert_y(self) -> Self {
-                Self {
-                    x: self.x,
-                    y: -self.y,
-                }
+            fn invert_y(self) -> Self {
+                Self::new(self.x, -self.y)
             }
         }
     };
 }
 
-macro_rules! impl_ops_rhs {
-    ($name:ident, $t:ty) => {
-        impl $name {
-            pub const fn add_x(self, value: $t) -> Self {
-                Self {
-                    x: self.x + value,
-                    y: self.y,
-                }
-            }
+pub type Vector = nalgebra::Vector2<f64>;
+pub type Position = nalgebra::Point2<f64>;
+pub type Size = nalgebra::Vector2<f64>;
 
-            pub const fn add_y(self, value: $t) -> Self {
-                Self {
-                    x: self.x,
-                    y: self.y + value,
-                }
-            }
-
-            pub const fn sub_x(self, value: $t) -> Self {
-                Self {
-                    x: self.x - value,
-                    y: self.y,
-                }
-            }
-
-            pub const fn sub_y(self, value: $t) -> Self {
-                Self {
-                    x: self.x,
-                    y: self.y - value,
-                }
-            }
-
-            pub const fn mul_x(self, value: $t) -> Self {
-                Self {
-                    x: self.x * value,
-                    y: self.y,
-                }
-            }
-
-            pub const fn mul_y(self, value: $t) -> Self {
-                Self {
-                    x: self.x,
-                    y: self.y * value,
-                }
-            }
-
-            pub const fn div_x(self, value: $t) -> Self {
-                Self {
-                    x: self.x / value,
-                    y: self.y,
-                }
-            }
-
-            pub const fn div_y(self, value: $t) -> Self {
-                Self {
-                    x: self.x,
-                    y: self.y / value,
-                }
-            }
-        }
-    };
-}
-
-// Represents an offset (vector) from a position
-impl_constructor!(Vector, f64);
-impl_consts!(Vector, f64);
 impl_invert!(Vector);
-impl_ops_self!(Vector);
-impl_ops_rhs!(Vector, f64);
-
-// Represents a point
-impl_constructor!(Position, f64);
-impl_consts!(Position, f64);
 impl_invert!(Position);
-impl_ops_self!(Position);
-impl_ops_rhs!(Position, f64);
-
-// Represents a size
-// not using terms like length/width/height because they are ambiguous
-impl_constructor!(Size, f64);
-impl_consts!(Size, f64);
-impl_invert!(Size);
-impl_ops_self!(Size);
-impl_ops_rhs!(Size, f64);
 
 pub mod deduplicate {
     use crate::Position;
@@ -369,10 +145,7 @@ pub mod deduplicate {
 
         #[test]
         fn test_single_element() {
-            let vertices = vec![Position {
-                x: 1.0,
-                y: 2.0,
-            }];
+            let vertices = vec![Position::new(1.0, 2.0)];
             let result = vertices.dedup_with_epsilon(0.001);
             assert_eq!(result.len(), 1);
             assert_eq!(result[0].x, 1.0);
@@ -382,18 +155,9 @@ pub mod deduplicate {
         #[test]
         fn test_no_duplicates() {
             let vertices = vec![
-                Position {
-                    x: 0.0,
-                    y: 0.0,
-                },
-                Position {
-                    x: 1.0,
-                    y: 1.0,
-                },
-                Position {
-                    x: 2.0,
-                    y: 2.0,
-                },
+                Position::new(0.0, 0.0),
+                Position::new(1.0, 1.0),
+                Position::new(2.0, 2.0),
             ];
 
             let expected_result = vertices.clone();
@@ -408,54 +172,24 @@ pub mod deduplicate {
         #[test]
         fn test_with_adjacent_duplicates() {
             let vertices = vec![
-                Position {
-                    x: 0.0,
-                    y: 0.0,
-                },
-                Position {
-                    x: 0.0,
-                    y: 0.0,
-                }, // dup
-                Position {
-                    x: 1.0,
-                    y: 1.0,
-                },
-                Position {
-                    x: 2.0,
-                    y: 2.0,
-                },
+                Position::new(0.0, 0.0),
+                Position::new(0.0, 0.0),
+                Position::new(1.0, 1.0),
+                Position::new(2.0, 2.0),
             ];
             let result = vertices.dedup_with_epsilon(1e-6);
             assert_eq!(result.len(), 3);
-            assert_eq!(result[0], Position {
-                x: 0.0,
-                y: 0.0
-            });
-            assert_eq!(result[1], Position {
-                x: 1.0,
-                y: 1.0
-            });
-            assert_eq!(result[2], Position {
-                x: 2.0,
-                y: 2.0
-            });
+            assert_eq!(result[0], Position::new(0.0, 0.0));
+            assert_eq!(result[1], Position::new(1.0, 1.0));
+            assert_eq!(result[2], Position::new(2.0, 2.0));
         }
 
         #[test]
         fn test_dedup_would_leave_too_few() {
             let vertices = vec![
-                Position {
-                    x: 0.0,
-                    y: 0.0,
-                },
-                Position {
-                    x: 0.0,
-                    y: 0.0,
-                }, // dup
-                Position {
-                    x: 0.0,
-                    y: 0.0,
-                }, // dup
+                Position::new(0.0, 0.0),
+                Position::new(0.0, 0.0),
+                Position::new(0.0, 0.0),
             ];
             let result = vertices
                 .clone()
@@ -467,66 +201,27 @@ pub mod deduplicate {
         fn test_dedup_edge_epsilon() {
             // given
             let vertices = vec![
-                Position {
-                    x: 0.0,
-                    y: 0.0,
-                },
+                Position::new(0.0, 0.0),
                 // ensure positive numbers on y axis are detected
-                Position {
-                    x: 0.0,
-                    y: 0.0000005,
-                }, // Within epsilon of first point
-                Position {
-                    x: 0.0,
-                    y: 0.0000009,
-                }, // Within epsilon of removed point and first point
+                Position::new(0.0, 0.0000005), // Within epsilon of first point
+                Position::new(0.0, 0.0000009), // Within epsilon of removed point and first point
                 // ensure negative numbers on x axis are detected
-                Position {
-                    x: -3.0000000,
-                    y: 1.0,
-                },
-                Position {
-                    x: -3.0000001,
-                    y: 1.0,
-                }, // Within epsilon
+                Position::new(-3.0000000, 1.0),
+                Position::new(-3.0000001, 1.0), // Within epsilon
                 // ensure negative numbers on y axis are detected
-                Position {
-                    x: 2.0,
-                    y: -2.0,
-                },
-                Position {
-                    x: 2.0,
-                    y: -2.0000001,
-                },
+                Position::new(2.0, -2.0),
+                Position::new(2.0, -2.0000001),
                 // ensure positive numbers on x axis are detected
-                Position {
-                    x: 4.0,
-                    y: 0.0,
-                },
-                Position {
-                    x: 4.00000001,
-                    y: 0.0,
-                },
+                Position::new(4.0, 0.0),
+                Position::new(4.00000001, 0.0),
             ];
 
             // and
             let expected_result = vec![
-                Position {
-                    x: 0.0,
-                    y: 0.0,
-                },
-                Position {
-                    x: -3.0,
-                    y: 1.0,
-                },
-                Position {
-                    x: 2.0,
-                    y: -2.0,
-                },
-                Position {
-                    x: 4.0,
-                    y: 0.0,
-                },
+                Position::new(0.0, 0.0),
+                Position::new(-3.0, 1.0),
+                Position::new(2.0, -2.0),
+                Position::new(4.0, 0.0),
             ];
 
             // when

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use crate::Position;
+use nalgebra::Point2;
 
 pub(crate) enum Winding {
     /// Aka 'Positive' in Geometry
@@ -8,7 +8,7 @@ pub(crate) enum Winding {
 }
 
 impl Winding {
-    pub(crate) fn from_vertices(vertices: &[Position]) -> Self {
+    pub(crate) fn from_vertices(vertices: &[Point2<f64>]) -> Self {
         let mut sum = 0.0;
         for i in 0..vertices.len() {
             let j = (i + 1) % vertices.len();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -21,7 +21,7 @@ impl UiState {
         self.handle_zooming(view_state, &response, ui);
 
         self.center_screen_pos = viewport.center();
-        self.origin_screen_pos = view_state.gerber_to_screen_coords(Position::ZERO);
+        self.origin_screen_pos = view_state.gerber_to_screen_coords(Position::new(0.0, 0.0));
 
         trace!(
             "update. view_state: {:?}, viewport: {:?}, cursor_gerber_coords: {:?}",

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,7 @@
 use egui::{Pos2, Rect, Response, Ui};
 use log::trace;
+use nalgebra::Point2;
 
-use crate::spacial::Position;
 use crate::ViewState;
 
 #[derive(Debug, Default)]
@@ -11,7 +11,7 @@ pub struct UiState {
     pub origin_screen_pos: Pos2,
 
     // only valid if the mouse is over the viewport
-    pub cursor_gerber_coords: Option<Position>,
+    pub cursor_gerber_coords: Option<Point2<f64>>,
 }
 
 impl UiState {
@@ -21,7 +21,7 @@ impl UiState {
         self.handle_zooming(view_state, &response, ui);
 
         self.center_screen_pos = viewport.center();
-        self.origin_screen_pos = view_state.gerber_to_screen_coords(Position::new(0.0, 0.0));
+        self.origin_screen_pos = view_state.gerber_to_screen_coords(Point2::new(0.0, 0.0));
 
         trace!(
             "update. view_state: {:?}, viewport: {:?}, cursor_gerber_coords: {:?}",


### PR DESCRIPTION
This PR transitions the gerber_viewer create to using Point2<f64> and Vector2<f64> from nalgebra,  instead of re-inventing the wheel for 2D operations.

my rationale is that I don't want my other crates to have to depend on types defined by a gerber_viewer crate, but both the gerber_viewer itself, and downstrea crates need types that represent the same 2D concepts, so it makes sense to use a (*very*) popular library for it.